### PR TITLE
Merged PR 1: FIX - UpdateInStore overlapping ranges exceeding LogMaxD…

### DIFF
--- a/src/Framework/FrameworkExtensions.cs
+++ b/src/Framework/FrameworkExtensions.cs
@@ -578,5 +578,29 @@ namespace PDS.WITSMLstudio.Framework
 
             return null;
         }
+
+
+        /// <summary>
+        /// Takes an incoming IEnumerable of T and splits it into "chunks" specified by size with the last partition containing whatever was left over
+        /// </summary>
+        /// <param name="sequence">the original enumerable to split up</param>
+        /// <param name="size">the size of each partition</param>
+        /// <typeparam name="T">generic type for enumerable</typeparam>
+        /// <returns>an enumerable of enumerable chunks sized to match the size parameter, in original order</returns>
+        public static IEnumerable<IEnumerable<T>> Partition<T>(this IEnumerable<T> sequence, int size)
+        {
+            List<T> partition = new List<T>(size);
+            foreach (var item in sequence)
+            {
+                partition.Add(item);
+                if (partition.Count == size)
+                {
+                    yield return partition;
+                    partition = new List<T>(size);
+                }
+            }
+            if (partition.Count > 0)
+                yield return partition;
+        }
     }
 }


### PR DESCRIPTION
…ataNodesGet size

Fixes the issue where overlapping range updates exceeded the fetch row limit when merging chunks.

Related work items: #2